### PR TITLE
Cancel subscriptions via enrollment service

### DIFF
--- a/app/services/subscriptions.py
+++ b/app/services/subscriptions.py
@@ -29,12 +29,14 @@ def get_active_subscriptions(guardian: Guardian):
     ).all()
 
 def cancel_subscription(sub: Subscription, *, cancel_enrollments: bool = True, end_date: date | None = None):
+    from . import enrollments as enrollment_service
+
     sub.status = SubscriptionStatus.canceled
     sub.end_date = end_date or date.today()
     if cancel_enrollments:
         for enrollment in sub.enrollments:
             if enrollment.status == EnrollmentStatus.active:
-                enrollment.status = EnrollmentStatus.canceled
+                enrollment_service.cancel_enrollment(enrollment)
     return sub
 
 def activate_subscription(sub: Subscription):

--- a/tests/test_admin_subscriptions.py
+++ b/tests/test_admin_subscriptions.py
@@ -274,9 +274,9 @@ def test_full_subscription_flow(client, app, admin_data):
     with app.app_context():
         subscription = db.session.get(Subscription, admin_data["subscription_id"])
         assert subscription.status == SubscriptionStatus.canceled
-        assert subscription.end_date is not None
-        for enrollment in subscription.enrollments:
-            assert enrollment.status != EnrollmentStatus.active
+        assert subscription.end_date == date.today()
+        assert all(enrollment.status != EnrollmentStatus.active for enrollment in subscription.enrollments)
+        assert any(enrollment.status == EnrollmentStatus.canceled for enrollment in subscription.enrollments)
 
     reactivate_resp = client.post(
         detail_url,

--- a/tests/test_subscription_service.py
+++ b/tests/test_subscription_service.py
@@ -1,0 +1,117 @@
+import sys
+from datetime import date, time
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from app import create_app
+from app.extensions import db
+from app.models import (
+    BillingCycle,
+    Child,
+    DayOfWeek,
+    Enrollment,
+    EnrollmentStatus,
+    Guardian,
+    KnowledgeLevel,
+    Plan,
+    Subscription,
+    SubscriptionStatus,
+    User,
+    Workshop,
+)
+from app.services import subscriptions as subscription_service
+
+
+class TestConfig:
+    TESTING = True
+    SECRET_KEY = "test-secret"
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    WTF_CSRF_ENABLED = False
+    MAIL_SUPPRESS_SEND = True
+
+
+@pytest.fixture
+def app():
+    app = create_app(TestConfig)
+    with app.app_context():
+        db.create_all()
+    yield app
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+
+
+def test_cancel_subscription_cancels_active_enrollments_and_sets_end_date(app):
+    with app.app_context():
+        user = User(email="guardian@example.com", name="Guardian", password_hash="")
+        user.set_password("secret")
+        user.activate()
+        db.session.add(user)
+
+        guardian = Guardian(user=user, phone="+56900000000", allow_whatsapp_group=False)
+        db.session.add(guardian)
+
+        plan = Plan(
+            name="Plan Test",
+            max_children=2,
+            max_workshops_per_child=2,
+            price_monthly=20000,
+            quarterly_discount_pct=0,
+            is_active=True,
+        )
+        db.session.add(plan)
+
+        workshop = Workshop(
+            name="Taller Test",
+            day_of_week=DayOfWeek.lunes,
+            start_time=time(10, 0),
+            end_time=time(11, 0),
+            is_active=True,
+        )
+        db.session.add(workshop)
+
+        subscription = Subscription(
+            guardian=guardian,
+            plan=plan,
+            billing_cycle=BillingCycle.monthly,
+            status=SubscriptionStatus.active,
+            start_date=date(2024, 1, 1),
+        )
+        db.session.add(subscription)
+
+        child = Child(
+            guardian=guardian,
+            name="Niña Uno",
+            birthdate=date(2015, 6, 1),
+            knowledge_level=KnowledgeLevel.basic,
+            allow_media=True,
+        )
+        db.session.add(child)
+
+        active_enrollment = Enrollment(
+            subscription=subscription,
+            child=child,
+            workshop=workshop,
+            status=EnrollmentStatus.active,
+        )
+        already_canceled = Enrollment(
+            subscription=subscription,
+            child=child,
+            workshop=workshop,
+            status=EnrollmentStatus.canceled,
+        )
+        db.session.add_all([active_enrollment, already_canceled])
+        db.session.flush()
+
+        subscription_service.cancel_subscription(subscription)
+        db.session.flush()
+
+        assert subscription.status == SubscriptionStatus.canceled
+        assert subscription.end_date == date.today()
+        assert all(enrollment.status == EnrollmentStatus.canceled for enrollment in subscription.enrollments)


### PR DESCRIPTION
## Summary
- update subscription cancellation to delegate enrollment termination to the enrollment service and set the end date
- cover subscription cancellation with unit and functional tests to ensure enrollments end up canceled

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e304910698832b91a4ca2a5e58f447