### PR TITLE
Remove unused subscription helper

### DIFF
--- a/app/services/subscriptions.py
+++ b/app/services/subscriptions.py
@@ -23,11 +23,6 @@ def create_subscription(guardian: Guardian, plan: Plan,
     db.session.add(sub)
     return sub
 
-def get_active_subscriptions(guardian: Guardian):
-    return Subscription.query.filter_by(
-        guardian_id=guardian.id, status=SubscriptionStatus.active
-    ).all()
-
 def cancel_subscription(sub: Subscription, *, cancel_enrollments: bool = True, end_date: date | None = None):
     from . import enrollments as enrollment_service
 


### PR DESCRIPTION
## Summary
- remove the unused `get_active_subscriptions` helper from the subscription service

## Testing
- pytest tests/test_admin_subscriptions.py

------
https://chatgpt.com/codex/tasks/task_e_68e30ac377a4832baef29f31c9853fcd