### PR TITLE
Add renewal workflow for subscription payment orders

### DIFF
--- a/app/services/orders.py
+++ b/app/services/orders.py
@@ -1,6 +1,13 @@
 # services/orders.py
 from .subscriptions import activate_subscription
-from ..models import Order, PaymentMethod, PaymentStatus, Subscription, SubscriptionStatus
+from ..models import (
+    Order,
+    PaymentMethod,
+    PaymentStatus,
+    Subscription,
+    SubscriptionStatus,
+    BillingCycle,
+)
 from ..extensions import db
 
 def create_order(subscription: Subscription, amount_clp: int,
@@ -28,4 +35,25 @@ def mark_order_pending(order: Order):
     """Reabre la orden (por ejemplo, si se confirmó por error)."""
     order.payment_status = PaymentStatus.pending
     return order
+
+
+def calculate_subscription_amount(subscription: Subscription) -> int:
+    """Retorna el monto correspondiente al ciclo de facturación de la suscripción."""
+    plan = subscription.plan
+    if subscription.billing_cycle == BillingCycle.monthly:
+        return plan.price_monthly
+    return int(
+        plan.price_monthly
+        * 3
+        * (1 - (subscription.plan.quarterly_discount_pct / 100))
+    )
+
+
+def create_billing_cycle_order(
+    subscription: Subscription, payment_method: PaymentMethod | None = None
+) -> Order:
+    """Crea una nueva orden para el siguiente ciclo de facturación de la suscripción."""
+    method = payment_method or PaymentMethod.in_person
+    amount = calculate_subscription_amount(subscription)
+    return create_order(subscription, amount, method)
 

--- a/app/templates/admin/dashboard_payments.html
+++ b/app/templates/admin/dashboard_payments.html
@@ -25,6 +25,75 @@
     </div>
 </div>
 
+<!-- Suscripciones que necesitan reemitir orden -->
+<div class="card mb-4">
+    <div class="card-header">
+        Renovación de órdenes de pago
+    </div>
+    <div class="card-body p-0">
+        {% if subscriptions_due %}
+            <div class="table-responsive">
+                <table class="table table-striped align-middle mb-0">
+                    <thead class="table-dark">
+                    <tr>
+                        <th>Apoderado</th>
+                        <th>Plan</th>
+                        <th>Última orden</th>
+                        <th>Próxima emisión</th>
+                        <th class="text-center">Monto</th>
+                        <th class="text-center">Acción</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for item in subscriptions_due %}
+                        <tr>
+                            <td>
+                                {{ item.subscription.guardian.user.name }}<br>
+                                <small class="text-muted">{{ item.subscription.guardian.user.email }}</small>
+                            </td>
+                            <td>
+                                {{ item.subscription.plan.name }}<br>
+                                <small class="text-muted">{{ item.subscription.billing_cycle.value }}</small>
+                            </td>
+                            <td>
+                                {% if item.last_order %}
+                                    #{{ item.last_order.id }} · {{ item.last_order.payment_status.value }}<br>
+                                    <small class="text-muted">Emitida el {{ item.last_order.created_at.strftime('%d-%m-%Y') }}</small><br>
+                                    <small class="text-muted">Método sugerido: {{ item.recommended_method.value }}</small>
+                                {% else %}
+                                    <span class="text-muted">Sin órdenes registradas</span><br>
+                                    <small class="text-muted">Método sugerido: {{ item.recommended_method.value }}</small>
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if item.days_overdue > 0 %}
+                                    <span class="text-danger fw-semibold">Vencida hace {{ item.days_overdue }} día{% if item.days_overdue != 1 %}s{% endif %}</span><br>
+                                {% else %}
+                                    <span class="text-warning fw-semibold">Emitir hoy</span><br>
+                                {% endif %}
+                                <small class="text-muted">{{ item.reason }}</small><br>
+                                <small class="text-muted">Próxima fecha: {{ item.due_date.strftime('%d-%m-%Y') }}</small>
+                            </td>
+                            <td class="text-center">
+                                ${{ "{:,}".format(item.amount_clp).replace(",", ".") }} CLP
+                            </td>
+                            <td class="text-center">
+                                <form action="{{ url_for('admin.issue_subscription_order', subscription_id=item.subscription.id) }}" method="post">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                    <button class="btn btn-primary btn-sm">Emitir orden</button>
+                                </form>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% else %}
+            <p class="text-muted m-3">Todas las suscripciones activas están al día.</p>
+        {% endif %}
+    </div>
+</div>
+
 <!-- Tabla de órdenes pendientes -->
 <div class="card">
     <div class="card-header">

--- a/tests/test_admin_payments.py
+++ b/tests/test_admin_payments.py
@@ -1,0 +1,148 @@
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from app import create_app
+from app.extensions import db
+from app.models import (
+    User,
+    Guardian,
+    Plan,
+    Subscription,
+    PaymentStatus,
+    PaymentMethod,
+    SubscriptionStatus,
+    BillingCycle,
+    Order,
+)
+
+
+class TestConfig:
+    TESTING = True
+    SECRET_KEY = "test-secret"
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    WTF_CSRF_ENABLED = False
+    MAIL_SUPPRESS_SEND = True
+    INITIAL_PASSWORD_TOKEN_MAX_AGE = 3600
+
+
+@pytest.fixture
+def app():
+    app = create_app(TestConfig)
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def admin_setup(app):
+    with app.app_context():
+        now = datetime.now(timezone.utc)
+
+        admin = User(email="admin@example.com", name="Admin", password_hash="", is_admin=True)
+        admin.set_password("secret")
+        admin.activate()
+        admin.email_confirmed_at = now
+        db.session.add(admin)
+
+        guardian_user = User(email="guardian@example.com", name="Guardian Uno", password_hash="")
+        guardian_user.set_password("guardian")
+        guardian_user.activate()
+        guardian_user.email_confirmed_at = now
+        db.session.add(guardian_user)
+        db.session.flush()
+
+        guardian = Guardian(user=guardian_user, phone="+56911111111", allow_whatsapp_group=False)
+        db.session.add(guardian)
+
+        plan = Plan(
+            name="Plan Familiar",
+            max_children=2,
+            max_workshops_per_child=2,
+            price_monthly=25000,
+            quarterly_discount_pct=10,
+            is_active=True,
+        )
+        db.session.add(plan)
+        db.session.flush()
+
+        subscription = Subscription(
+            guardian=guardian,
+            plan=plan,
+            billing_cycle=BillingCycle.monthly,
+            status=SubscriptionStatus.active,
+            start_date=date(2024, 1, 1),
+        )
+        db.session.add(subscription)
+        db.session.flush()
+
+        last_order = Order(
+            subscription=subscription,
+            amount_clp=plan.price_monthly,
+            payment_method=PaymentMethod.transfer,
+            payment_status=PaymentStatus.paid,
+        )
+        last_order.created_at = now - timedelta(days=40)
+        db.session.add(last_order)
+        db.session.commit()
+
+        return {
+            "admin_credentials": {"email": admin.email, "password": "secret"},
+            "subscription_id": subscription.id,
+            "expected_amount": plan.price_monthly,
+        }
+
+
+def login(client, credentials):
+    return client.post("/auth/login", data=credentials, follow_redirects=True)
+
+
+def test_dashboard_lists_subscriptions_due(client, admin_setup):
+    response = login(client, admin_setup["admin_credentials"])
+    assert response.status_code == 200
+
+    dashboard_response = client.get("/admin/dashboard/pagos")
+    assert dashboard_response.status_code == 200
+    assert b"Renovaci\xc3\xb3n de \xc3\xb3rdenes de pago" in dashboard_response.data
+    assert b"Emitir orden" in dashboard_response.data
+    assert b"guardian@example.com" in dashboard_response.data
+
+
+def test_issue_subscription_order_creates_new_pending_order(client, app, admin_setup):
+    login_response = login(client, admin_setup["admin_credentials"])
+    assert login_response.status_code == 200
+
+    subscription_id = admin_setup["subscription_id"]
+
+    issue_response = client.post(
+        f"/admin/dashboard/pagos/subscriptions/{subscription_id}/emitir",
+        follow_redirects=True,
+    )
+    assert issue_response.status_code == 200
+
+    with app.app_context():
+        orders = (
+            Order.query.filter_by(subscription_id=subscription_id)
+            .order_by(Order.created_at.desc())
+            .all()
+        )
+        assert len(orders) == 2
+        new_order = orders[0]
+        assert new_order.payment_status == PaymentStatus.pending
+        assert new_order.payment_method == PaymentMethod.transfer
+        assert new_order.amount_clp == admin_setup["expected_amount"]


### PR DESCRIPTION
## Summary
- surface subscriptions that need a new payment order on the admin dashboard based on each billing cycle
- add an action to generate the next cycle order reusing the previous payment method and amount helper
- cover the workflow with new tests for the dashboard listing and issuance behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e30e552f48832b9d5bf150c3cb2918