### PR TITLE
Fix Google Workspace mail defaults

### DIFF
--- a/config.py
+++ b/config.py
@@ -29,9 +29,9 @@ class Config:
     if _mail_provider in {"google_workspace", "gmail"}:
         _mail_defaults = {
             "MAIL_SERVER": "smtp.gmail.com",
-            "MAIL_PORT": 465,
-            "MAIL_USE_TLS": False,
-            "MAIL_USE_SSL": True,
+            "MAIL_PORT": 587,
+            "MAIL_USE_TLS": True,
+            "MAIL_USE_SSL": False,
         }
     else:
         _mail_defaults = {


### PR DESCRIPTION
## Summary
- update the Google Workspace/Gmail mail defaults to use STARTTLS on port 587 rather than implicit SSL on 465
- ensure new inscriptions use the expected TLS configuration when sending initial password emails

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e330b9f7c8832b9cb9488363e458ef