### PR TITLE
Fix Google Workspace mail defaults and add SMTP diagnostics

### DIFF
--- a/config.py
+++ b/config.py
@@ -29,9 +29,9 @@ class Config:
     if _mail_provider in {"google_workspace", "gmail"}:
         _mail_defaults = {
             "MAIL_SERVER": "smtp.gmail.com",
-            "MAIL_PORT": 465,
-            "MAIL_USE_TLS": False,
-            "MAIL_USE_SSL": True,
+            "MAIL_PORT": 587,
+            "MAIL_USE_TLS": True,
+            "MAIL_USE_SSL": False,
         }
     else:
         _mail_defaults = {

--- a/docs/mail_troubleshooting.md
+++ b/docs/mail_troubleshooting.md
@@ -1,0 +1,46 @@
+# SMTP troubleshooting
+
+Este repositorio incluye un pequeño script que permite diagnosticar problemas de conexión con el servidor SMTP configurado mediante variables de entorno compatibles con Flask-Mail.
+
+## Uso
+
+En el servidor (o localmente, si tienes las mismas variables definidas), ejecuta:
+
+```bash
+source venv/bin/activate
+python scripts/test_mail_connection.py
+```
+
+El script mostrará:
+
+- Host y puerto que está intentando usar.
+- Si la conexión se hace con SSL implícito o STARTTLS.
+- Si se proporcionó usuario y contraseña.
+- Resultado de la autenticación y de un comando `NOOP` para comprobar la conexión.
+
+Para activar trazas detalladas del protocolo SMTP, agrega la opción `--debug`:
+
+```bash
+python scripts/test_mail_connection.py --debug
+```
+
+Si necesitas forzar valores distintos (por ejemplo, otro puerto), puedes exportar variables antes de ejecutar el script:
+
+```bash
+export MAIL_PORT=587
+export MAIL_USE_TLS=true
+python scripts/test_mail_connection.py
+```
+
+## Interpretación de resultados
+
+- `Connection error`: indica que no se pudo establecer la conexión (DNS, red o firewall).
+- `login: authentication failed`: usuario/contraseña inválidos o falta de permiso (por ejemplo, si no se habilitó "Acceso a aplicaciones poco seguras" o la cuenta requiere OAuth).
+- `login: success` seguido de `NOOP command: success`: la cuenta quedó autenticada correctamente.
+- Usa `CTRL+C` para detener el script si queda en espera; esto puede ocurrir si hay un bloqueo de red.
+
+Una vez diagnosticado el problema, recuerda reiniciar Gunicorn para que tome las variables de entorno actualizadas:
+
+```bash
+sudo systemctl restart caissa
+```

--- a/scripts/test_mail_connection.py
+++ b/scripts/test_mail_connection.py
@@ -1,0 +1,109 @@
+"""Utility to test SMTP connectivity using Flask-Mail environment variables."""
+from __future__ import annotations
+
+import os
+import smtplib
+import ssl
+import sys
+from typing import Optional
+
+
+def _env_bool(key: str, default: bool = False) -> bool:
+    value = os.environ.get(key)
+    if value is None:
+        return default
+    value = value.strip().lower()
+    if value in {"1", "true", "t", "yes", "y"}:
+        return True
+    if value in {"0", "false", "f", "no", "n"}:
+        return False
+    return default
+
+
+def _env_int(key: str, default: int) -> int:
+    value = os.environ.get(key)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def main(argv: list[str]) -> int:
+    debug = "--debug" in argv
+
+    server = os.environ.get("MAIL_SERVER", "localhost")
+    port = _env_int("MAIL_PORT", 25)
+    use_tls = _env_bool("MAIL_USE_TLS", False)
+    use_ssl = _env_bool("MAIL_USE_SSL", False)
+    timeout = float(os.environ.get("MAIL_SEND_TIMEOUT", "15"))
+    username = os.environ.get("MAIL_USERNAME")
+    password_present = bool(os.environ.get("MAIL_PASSWORD"))
+
+    print("SMTP diagnostics")
+    print(f"  server: {server}:{port}")
+    print(f"  use_ssl: {use_ssl}")
+    print(f"  use_tls: {use_tls}")
+    print(f"  timeout: {timeout}s")
+    print(f"  username provided: {bool(username)}")
+    print(f"  password provided: {password_present}")
+
+    smtp: Optional[smtplib.SMTP] = None
+
+    try:
+        if use_ssl:
+            context = ssl.create_default_context()
+            smtp = smtplib.SMTP_SSL(server, port, timeout=timeout, context=context)
+        else:
+            smtp = smtplib.SMTP(server, port, timeout=timeout)
+
+        if debug and smtp is not None:
+            smtp.set_debuglevel(1)
+
+        smtp.ehlo()
+
+        if use_tls and not use_ssl:
+            context = ssl.create_default_context()
+            smtp.starttls(context=context)
+            smtp.ehlo()
+
+        if username:
+            try:
+                smtp.login(username, os.environ.get("MAIL_PASSWORD", ""))
+                print("  login: success")
+            except smtplib.SMTPHeloError as exc:
+                print(f"  login: failed during HELO/EHLO: {exc}")
+            except smtplib.SMTPAuthenticationError as exc:
+                print(f"  login: authentication failed: {exc.smtp_error.decode(errors='ignore') if isinstance(exc.smtp_error, bytes) else exc.smtp_error}")
+            except smtplib.SMTPException as exc:
+                print(f"  login: other SMTP error: {exc}")
+            except Exception as exc:  # pragma: no cover - unexpected errors
+                print(f"  login: unexpected error: {exc}")
+            else:
+                try:
+                    smtp.noop()
+                    print("  NOOP command: success")
+                except smtplib.SMTPException as exc:
+                    print(f"  NOOP command: error: {exc}")
+        else:
+            try:
+                smtp.noop()
+                print("  NOOP command: success")
+            except smtplib.SMTPException as exc:
+                print(f"  NOOP command: error: {exc}")
+
+        return 0
+    except (OSError, smtplib.SMTPException) as exc:
+        print(f"Connection error: {exc}")
+        return 1
+    finally:
+        if smtp is not None:
+            try:
+                smtp.quit()
+            except Exception:
+                smtp.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- update the Google Workspace/Gmail mail defaults to use STARTTLS on port 587 rather than implicit SSL on 465
- ensure new inscriptions use the expected TLS configuration when sending initial password emails
- add a `scripts/test_mail_connection.py` helper and troubleshooting doc to diagnose SMTP connectivity directly from the server

## Testing
- not run (diagnostic tooling only)

------
https://chatgpt.com/codex/tasks/task_e_68e330b9f7c8832b9cb9488363e458ef