### PR TITLE
Adjust admin dashboard flash notifications

### DIFF
--- a/app/templates/admin/dashboard_base.html
+++ b/app/templates/admin/dashboard_base.html
@@ -83,12 +83,13 @@
     <!-- Main content -->
     <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4 py-3">
 
-      {# Flash messages (BS5) #}
+      {% block flash_messages %}
+      {# Flash messages (Bootstrap 5 toasts) #}
       {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
           <div class="toast-container position-fixed top-0 start-50 translate-middle-x p-3" style="z-index: 1080;">
             {% for category, message in messages %}
-              <div class="toast align-items-center text-bg-{{ 'warning' if category=='warning' else ('danger' if category=='danger' else ('success' if category=='success' else 'info')) }} border-0 show mb-2" role="alert" aria-live="assertive" aria-atomic="true">
+              <div class="toast align-items-center text-bg-{{ 'warning' if category=='warning' else ('danger' if category=='danger' else ('success' if category=='success' else 'info')) }} border-0 mb-2" role="alert" aria-live="assertive" aria-atomic="true" data-bs-autohide="true" data-bs-delay="5000">
                 <div class="d-flex">
                   <div class="toast-body">
                     {{ message }}
@@ -100,9 +101,23 @@
           </div>
         {% endif %}
       {% endwith %}
+      {% endblock %}
 
       {% block dashboard_content %}{% endblock %}
     </main>
   </div>
 </div>
+{% endblock %}
+
+{% block extra_scripts %}
+  {{ super() }}
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      var toastElList = [].slice.call(document.querySelectorAll('.toast'));
+      toastElList.forEach(function (toastEl) {
+        var toast = new bootstrap.Toast(toastEl);
+        toast.show();
+      });
+    });
+  </script>
 {% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -82,6 +82,7 @@
 
     <!-- Page content -->
     <main>
+        {% block flash_messages %}
         {% with messages = get_flashed_messages(with_categories=true) %}
             {% if messages %}
                 <div class="container mt-3">
@@ -94,6 +95,7 @@
                 </div>
             {% endif %}
         {% endwith %}
+        {% endblock %}
         {% block content %}{% endblock %}
     </main>
 


### PR DESCRIPTION
## Summary
- allow overriding the base template's flash message layout via a dedicated block
- render admin dashboard flashes as Bootstrap toasts that float without shifting the page
- initialize toast notifications so they display and auto-hide consistently

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3363fa400832bb8391fc4d57c6b68